### PR TITLE
Fixes issue #9

### DIFF
--- a/pluginlib/_loader.py
+++ b/pluginlib/_loader.py
@@ -28,9 +28,9 @@ from pluginlib._util import LOGGER, NoneType, PY_LT_3_10
 
 
 if PY_LT_3_10:  # pragma: no cover
-    from importlib_metadata import entry_points, EntryPoint  # pylint: disable=import-error
+    from importlib_metadata import entry_points  # pylint: disable=import-error
 else:
-    from importlib.metadata import entry_points, EntryPoint
+    from importlib.metadata import entry_points
 
 
 def _raise_friendly_exception(exc, name, path):
@@ -89,7 +89,7 @@ def _import_module(name, path=None):
 
     # If name is an entry point, try to parse it
     epoint = None
-    if isinstance(name, EntryPoint):
+    if hasattr(name, 'module'):
         epoint = name
         name = epoint.module
 

--- a/pluginlib/_loader.py
+++ b/pluginlib/_loader.py
@@ -24,12 +24,13 @@ from collections.abc import Iterable
 from pluginlib.exceptions import PluginImportError, EntryPointWarning
 from pluginlib._objects import BlacklistEntry
 from pluginlib._parent import get_plugins
-from pluginlib._util import LOGGER, NoneType, PY_LT_3_10
+from pluginlib._util import LOGGER, NoneType
 
 
-if PY_LT_3_10:  # pragma: no cover
+try:
+    # For Python <3.10 and debugpy
     from importlib_metadata import entry_points, EntryPoint  # pylint: disable=import-error
-else:
+except ImportError:
     from importlib.metadata import entry_points, EntryPoint
 
 

--- a/pluginlib/_util.py
+++ b/pluginlib/_util.py
@@ -13,13 +13,10 @@ This module contains generic functions for use in other modules
 import abc
 import logging
 import operator as _operator
-import sys
 import warnings
 from functools import update_wrapper, wraps
 from inspect import isclass
 
-
-PY_LT_3_10 = sys.version_info[:2] < (3, 10)
 
 # Setup logger
 LOGGER = logging.getLogger('pluginlib')

--- a/pylintrc
+++ b/pylintrc
@@ -52,6 +52,7 @@ spelling-ignore-words=
     argspecs, asyncio, attr, autoattribute, Args, Avram, Lubkin,
     basename, BlacklistEntry, bool, Boolean,
     classmethod, cls, coroutine,
+    debugpy,
     EntryPointWarning, errorcode, exc,
     FullArgSpec, func,
     getset,

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -16,7 +16,6 @@ from unittest import mock, TestCase
 
 import pluginlib._loader as loader
 from pluginlib._objects import OrderedDict
-from pluginlib._util import PY_LT_3_10
 from pluginlib import BlacklistEntry, PluginImportError, EntryPointWarning, PluginWarning
 
 from tests import OUTPUT
@@ -24,9 +23,10 @@ import tests.testdata
 import tests.testdata.parents
 
 
-if PY_LT_3_10:
+try:
+    # For Python <3.10 and debugpy
     from importlib_metadata import EntryPoint, EntryPoints  # pylint: disable=import-error
-else:
+except ImportError:
     from importlib.metadata import EntryPoint, EntryPoints
 
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix plugin loading for environments where entry point objects are not instances of the imported EntryPoint type by checking for a module attribute instead.